### PR TITLE
Adding routeGuard functionlaity

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,14 +5,15 @@ import { WelcomeComponent } from './welcome/welcome.component';
 import { ErrorComponent } from './error/error.component';
 import { ListTodosComponent } from './list-todos/list-todos.component';
 import { LogoutComponent } from './logout/logout.component';
+import { RouteGuardService } from './service/route-guard.service';
 
 
 const routes: Routes = [
   {path: "", component: LoginComponent},
   {path: "login", component: LoginComponent},
-  {path: "welcome/:name", component: WelcomeComponent},
-  {path: "todos", component: ListTodosComponent},
-  {path: "logout", component: LogoutComponent},
+  {path: "welcome/:name", component: WelcomeComponent, canActivate: [RouteGuardService]},
+  {path: "todos", component: ListTodosComponent, canActivate: [RouteGuardService]},
+  {path: "logout", component: LogoutComponent, canActivate: [RouteGuardService]},
   {path: "**", component: ErrorComponent}
 ];
 

--- a/src/app/service/route-guard.service.spec.ts
+++ b/src/app/service/route-guard.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { RouteGuardService } from './route-guard.service';
+
+describe('RouteGuardService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: RouteGuardService = TestBed.get(RouteGuardService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/service/route-guard.service.ts
+++ b/src/app/service/route-guard.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { HardcodedAuthenticationService } from './hardcoded-authentication.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RouteGuardService implements CanActivate {
+
+  constructor(private hardcodedAuthenticationService: HardcodedAuthenticationService) { }
+
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot){
+    if(this.hardcodedAuthenticationService.isUserLoggedIn()){
+      return true;
+    }
+    return false;
+   
+  }
+}


### PR DESCRIPTION
Earlier - if user types the url to go to login or todo or welcome it can directly access it there was no security

Now - Adding routeGuard service, If user got logged it will not allow any url to go to the required pages. It will put a guard on to the pages route link.